### PR TITLE
Unwrap nested objects and arrays

### DIFF
--- a/lib/object-verifyer.js
+++ b/lib/object-verifyer.js
@@ -67,13 +67,8 @@ function createWriter(tests, spec_options) {
   return (object, options = spec_options, base = undefined) => {
     object = unwrap(object);
     assertType(object, 'Object', base, options.error_code);
-    for (const key of Object.keys(object)) {
-      getTest(tests, key, base, options).verify(
-        object[key],
-        options,
-        key,
-        true
-      );
+    for (const [key, value] of Object.entries(object)) {
+      getTest(tests, key, base, options).verify(value, options, key, true);
     }
     return new Proxy(object, {
       get: createPropertyGetter(tests, options, base, 'write'),

--- a/lib/schema_object.test.js
+++ b/lib/schema_object.test.js
@@ -837,6 +837,16 @@ describe('schema object', () => {
 
       assert.isUndefined(proxy.some);
     });
+
+    it('uses toJSON representation of nested object when initializing', () => {
+      const original = { some: { nested: 'thing' } };
+      const reader = objectSchema.read(original);
+      const writer = objectSchema.write({ some: reader.some });
+
+      const raw = writer.toJSON();
+
+      assert.same(raw.some, original.some);
+    });
   });
 
   describe('write array', () => {

--- a/lib/util.js
+++ b/lib/util.js
@@ -39,7 +39,29 @@ function unwrap(value) {
     return value;
   }
   const { toJSON } = value;
-  return toJSON ? toJSON.call(value) : value;
+  if (toJSON) {
+    return toJSON.call(value);
+  }
+  switch (typeOf(value)) {
+    case 'Object':
+      return unwrapCopy(value, {});
+    case 'Array':
+      return unwrapCopy(value, []);
+    default:
+      return value;
+  }
+}
+
+function unwrapCopy(value, clone) {
+  let did_unwrap = false;
+  for (const [k, v] of Object.entries(value)) {
+    const u = unwrap(v);
+    clone[k] = u;
+    if (u !== v) {
+      did_unwrap = true;
+    }
+  }
+  return did_unwrap ? clone : value;
 }
 
 function assertType(value, type, base, error_code) {

--- a/lib/util.test.js
+++ b/lib/util.test.js
@@ -87,6 +87,79 @@ describe('util', () => {
 
       assert.isNull(result);
     });
+
+    it('returns toJSON result of object properties', () => {
+      const expected = Symbol('toJSON result');
+      const value = { prop: { toJSON: sinon.fake.returns(expected) } };
+
+      const result = unwrap(value);
+
+      assert.same(result.prop, expected);
+    });
+
+    it('returns given value if object properties do not implement toJSON', () => {
+      const expected = Symbol('toJSON result');
+      const value = { prop: expected };
+
+      const result = unwrap(value);
+
+      assert.same(result, value);
+      assert.same(result.prop, expected);
+    });
+
+    it('returns toJSON result of nested object properties', () => {
+      const expected = Symbol('toJSON result');
+      const value = {
+        nested: { prop: { toJSON: sinon.fake.returns(expected) } }
+      };
+
+      const result = unwrap(value);
+
+      assert.same(result.nested.prop, expected);
+    });
+
+    it('returns toJSON result of array entries', () => {
+      const expected = Symbol('toJSON result');
+      const value = [{ toJSON: sinon.fake.returns(expected) }];
+
+      const result = unwrap(value);
+
+      assert.isTrue(Array.isArray(result));
+      assert.equals(result.length, 1);
+      assert.same(result[0], expected);
+    });
+
+    it('returns given value if array entries do not implement toJSON', () => {
+      const expected = Symbol('toJSON result');
+      const value = [expected];
+
+      const result = unwrap(value);
+
+      assert.same(result, value);
+      assert.same(result[0], expected);
+    });
+
+    it('returns toJSON result of nested array entries', () => {
+      const expected = Symbol('toJSON result');
+      const value = { nested: [{ toJSON: sinon.fake.returns(expected) }] };
+
+      const result = unwrap(value);
+
+      assert.isTrue(Array.isArray(result.nested));
+      assert.equals(result.nested.length, 1);
+      assert.same(result.nested[0], expected);
+    });
+
+    it('returns toJSON result of array object property entries', () => {
+      const expected = Symbol('toJSON result');
+      const value = [{ prop: { toJSON: sinon.fake.returns(expected) } }];
+
+      const result = unwrap(value);
+
+      assert.isTrue(Array.isArray(result));
+      assert.equals(result.length, 1);
+      assert.same(result[0].prop, expected);
+    });
   });
 
   describe('assert-type', () => {


### PR DESCRIPTION
When assigning new objects to a writer with nested properties from a reader, the proxy object wasn't unwrapped.

With this fix the `unwrap` utility creates a clone of objects and arrays if nested properties implement `toJSON`. Otherwise the original value is returned.