### PR TITLE
Add read and write to opt

### DIFF
--- a/lib/opt.js
+++ b/lib/opt.js
@@ -2,6 +2,7 @@
 
 const { lookup } = require('./registry');
 const { validator } = require('./validator');
+const { copyPropertyDescriptor } = require('./util');
 
 exports.opt = opt;
 
@@ -20,6 +21,9 @@ function optSpecName(test) {
 }
 
 function optVerifyer(test) {
-  return (value, options = {}, base = undefined) =>
+  const verify = (value, options = {}, base = undefined) =>
     value === undefined ? value : test.verify(value, options, base);
+  copyPropertyDescriptor(test.verify, 'read', verify);
+  copyPropertyDescriptor(test.verify, 'write', verify);
+  return verify;
 }

--- a/lib/opt.test.js
+++ b/lib/opt.test.js
@@ -322,6 +322,40 @@ describe('opt', () => {
     );
   });
 
+  it('fails to access unknown property on reader', () => {
+    const optSchema = schema(opt({}));
+
+    const proxy = optSchema.read({});
+
+    assert.exception(
+      () => {
+        return proxy.foo;
+      },
+      {
+        name: 'ReferenceError',
+        message: 'Invalid property "foo"',
+        code: 'E_SCHEMA'
+      }
+    );
+  });
+
+  it('fails to access unknown property on writer', () => {
+    const optSchema = schema(opt({}));
+
+    const proxy = optSchema.write({});
+
+    assert.exception(
+      () => {
+        return proxy.foo;
+      },
+      {
+        name: 'ReferenceError',
+        message: 'Invalid property "foo"',
+        code: 'E_SCHEMA'
+      }
+    );
+  });
+
   it('does not add `verify` or toString to given function', () => {
     const fn = () => true;
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { lookup } = require('./registry');
+const { copyPropertyDescriptor } = require('./util');
 
 exports.schema = schema;
 
@@ -15,11 +16,4 @@ function schema(spec, spec_options = {}) {
 
 function createVerifyer(validator, spec_options) {
   return (value, options = spec_options) => validator.verify(value, options);
-}
-
-function copyPropertyDescriptor(from, name, to) {
-  const desc = Object.getOwnPropertyDescriptor(from, name);
-  if (desc) {
-    Object.defineProperty(to, name, desc);
-  }
 }

--- a/lib/schema_object.test.js
+++ b/lib/schema_object.test.js
@@ -3,7 +3,7 @@
 const { inspect } = require('util');
 const { EventEmitter } = require('events');
 const { assert, refute, match, sinon } = require('@sinonjs/referee-sinon');
-const { schema, object, array, map, number, string } = require('..');
+const { schema, object, array, map, number, string, opt } = require('..');
 
 describe('schema object', () => {
   it('fails to define schema with []', () => {
@@ -1150,6 +1150,27 @@ describe('schema object', () => {
     it('emits "set" event nested for property set', () => {
       const obj = {};
       const proxy = objectSchema.write({ some: obj }, { emitter });
+
+      proxy.some.nested = 'test';
+
+      assert.calledOnceWith(onSet, {
+        type: 'object',
+        object: match.same(obj),
+        key: 'nested',
+        value: 'test',
+        base: 'some',
+        path: 'some.nested'
+      });
+    });
+
+    it('emits "set" event nested, optional for property set', () => {
+      const optObjectSchema = schema({
+        some: opt({
+          nested: opt(string)
+        })
+      });
+      const obj = {};
+      const proxy = optObjectSchema.write({ some: obj }, { emitter });
 
       proxy.some.nested = 'test';
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -10,6 +10,7 @@ exports.assertType = assertType;
 exports.lazy = lazy;
 exports.typeOf = typeOf;
 exports.stringify = stringify;
+exports.copyPropertyDescriptor = copyPropertyDescriptor;
 
 exports.failSchemaValidation = failSchemaValidation;
 exports.failType = failType;
@@ -92,6 +93,13 @@ const serialize = {
 
 function stringify(value) {
   return (serialize[typeOf(value)] || JSON.stringify)(value);
+}
+
+function copyPropertyDescriptor(from, name, to) {
+  const desc = Object.getOwnPropertyDescriptor(from, name);
+  if (desc) {
+    Object.defineProperty(to, name, desc);
+  }
 }
 
 function failSchemaValidation(error, error_code = E_SCHEMA) {

--- a/lib/util.test.js
+++ b/lib/util.test.js
@@ -9,7 +9,8 @@ const {
   assertType,
   lazy,
   typeOf,
-  stringify
+  stringify,
+  copyPropertyDescriptor
 } = require('./util');
 
 describe('util', () => {
@@ -327,6 +328,39 @@ describe('util', () => {
       const type = stringify(/[a-z]/i);
 
       assert.equals(type, '/[a-z]/i');
+    });
+  });
+
+  describe('copyPropertyDescriptor', () => {
+    it('does nothing if the named property descriptor does not exist', () => {
+      const from = {};
+      const to = {};
+
+      copyPropertyDescriptor(from, 'test', to);
+
+      assert.isFalse(Object.prototype.hasOwnProperty.call(to, 'test'));
+    });
+
+    it('copies the named property descriptor', () => {
+      const desc = {
+        enumerable: true,
+        get() {
+          return 'Hi';
+        }
+      };
+      const from = Object.create(null, {
+        test: desc
+      });
+      const to = {};
+
+      copyPropertyDescriptor(from, 'test', to);
+
+      assert.equals(Object.getOwnPropertyDescriptor(to, 'test'), {
+        get: desc.get,
+        set: undefined,
+        configurable: false,
+        enumerable: true
+      });
     });
   });
 });


### PR DESCRIPTION
`opt` was missing `read` and `write` operations from the wrapped object.