### PR TITLE
Fix paths in events for objects in arrays

### DIFF
--- a/lib/array-verifyer.js
+++ b/lib/array-verifyer.js
@@ -34,7 +34,7 @@ function createVerify(itemTest) {
 function createArrayItemReader(itemTest, verify) {
   return (array, options = {}, base = undefined) => {
     return new Proxy(verify(unwrap(array), options), {
-      get: createItemGetter(itemTest, options, base, 'read'),
+      get: createItemGetter(itemTest, options, base, 'read', arrayPath),
       set: failSet,
       deleteProperty: failDelete
     });
@@ -49,7 +49,7 @@ function createArrayItemWriter(itemTest, item_spec) {
       emitArrayEvents(array, emitter, base, itemTest, item_spec);
     }
     return new Proxy(array, {
-      get: createItemGetter(itemTest, options, base, 'write'),
+      get: createItemGetter(itemTest, options, base, 'write', arrayPath),
       set(target, key, value) {
         if (typeof key === 'string' && key !== 'length') {
           value = unwrap(value);

--- a/lib/create-item-getter.js
+++ b/lib/create-item-getter.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const { objectPath } = require('./util');
-
 exports.createItemGetter = createItemGetter;
 
-function createItemGetter(valueTest, options, parent, read_write) {
+function createItemGetter(valueTest, options, parent, read_write, makePath) {
   const cache = Object.create(null);
   return (target, key) => {
     if (key === 'toJSON') {
@@ -24,7 +22,7 @@ function createItemGetter(valueTest, options, parent, read_write) {
       if (factory) {
         return (
           cache[key] ||
-          (cache[key] = factory(value, options, objectPath(parent, key)))
+          (cache[key] = factory(value, options, makePath(parent, key)))
         );
       }
     }

--- a/lib/map-verifyer.js
+++ b/lib/map-verifyer.js
@@ -34,7 +34,7 @@ function createVerify(keyVerify, valueTest) {
 function createMapValueReader(valueTest, verify) {
   return (map, options, base) => {
     return new Proxy(verify(unwrap(map), options), {
-      get: createItemGetter(valueTest, options, base, 'read'),
+      get: createItemGetter(valueTest, options, base, 'read', objectPath),
       set: failSet,
       deleteProperty: failDelete
     });
@@ -44,7 +44,7 @@ function createMapValueReader(valueTest, verify) {
 function createMapValueWriter(valueTest) {
   return (map, options, base) => {
     return new Proxy(unwrap(map), {
-      get: createItemGetter(valueTest, options, base, 'write'),
+      get: createItemGetter(valueTest, options, base, 'write', objectPath),
       set: createItemSetter(valueTest, options, base),
       deleteProperty(target, key) {
         if (options.emitter && typeof key === 'string') {

--- a/lib/schema_object.test.js
+++ b/lib/schema_object.test.js
@@ -1076,7 +1076,7 @@ describe('schema object', () => {
         {
           name: 'Error',
           message:
-            'Expected property "array.0.index" to be number ' +
+            'Expected property "array[0].index" to be number ' +
             'but got "invalid"',
           code: 'E_SCHEMA'
         }
@@ -1238,6 +1238,7 @@ describe('schema object', () => {
       some: {
         nested: string,
         array: array(number),
+        array_object: array({ num: number }),
         map: map(string, number)
       }
     });
@@ -1346,6 +1347,25 @@ describe('schema object', () => {
       });
     });
 
+    it('emits "set" event for nested array object assign', () => {
+      const original = { num: 7 };
+      const proxy = objectSchema.write(
+        { some: { array_object: [original] } },
+        { emitter }
+      );
+
+      proxy.some.array_object[0].num = 42;
+
+      assert.calledOnceWith(onSet, {
+        type: 'object',
+        object: match.same(original),
+        key: 'num',
+        value: 42,
+        base: 'some.array_object[0]',
+        path: 'some.array_object[0].num'
+      });
+    });
+
     it('emits "delete" event for nested array delete', () => {
       const original = [2, 3, 7];
       const proxy = objectSchema.write(
@@ -1361,6 +1381,24 @@ describe('schema object', () => {
         index: 2,
         base: 'some.array',
         path: 'some.array[2]'
+      });
+    });
+
+    it('emits "delete" event for nested array object delete', () => {
+      const original = { num: 7 };
+      const proxy = objectSchema.write(
+        { some: { array_object: [original] } },
+        { emitter }
+      );
+
+      delete proxy.some.array_object[0].num;
+
+      assert.calledOnceWith(onDelete, {
+        type: 'object',
+        object: match.same(original),
+        key: 'num',
+        base: 'some.array_object[0]',
+        path: 'some.array_object[0].num'
       });
     });
 


### PR DESCRIPTION
Paths of objects nested in arrays where generated as `array.0.prop` instead of `array[0].prop`.