### PR TITLE
Clear cache entries on modify

### DIFF
--- a/lib/array-verifyer.js
+++ b/lib/array-verifyer.js
@@ -33,8 +33,9 @@ function createVerify(itemTest) {
 
 function createArrayItemReader(itemTest, verify) {
   return (array, options = {}, base = undefined) => {
+    const cache = [];
     return new Proxy(verify(unwrap(array), options), {
-      get: createItemGetter(itemTest, options, base, 'read', arrayPath),
+      get: createItemGetter(cache, itemTest, options, base, 'read', arrayPath),
       set: failSet,
       deleteProperty: failDelete
     });
@@ -48,10 +49,12 @@ function createArrayItemWriter(itemTest, item_spec) {
     if (emitter) {
       emitArrayEvents(array, emitter, base, itemTest, item_spec);
     }
+    const cache = [];
     return new Proxy(array, {
-      get: createItemGetter(itemTest, options, base, 'write', arrayPath),
+      get: createItemGetter(cache, itemTest, options, base, 'write', arrayPath),
       set(target, key, value) {
         if (typeof key === 'string' && key !== 'length') {
+          delete cache[key];
           value = unwrap(value);
           const index = getArrayIndex(key, base);
           const path = arrayPath(base, index);
@@ -70,6 +73,7 @@ function createArrayItemWriter(itemTest, item_spec) {
         return Reflect.set(target, key, value);
       },
       deleteProperty(target, key) {
+        delete cache[key];
         if (emitter) {
           const index = getArrayIndex(key, base);
           const path = arrayPath(base, index);

--- a/lib/array.test.js
+++ b/lib/array.test.js
@@ -221,6 +221,15 @@ describe('array', () => {
       refute.same(raw, writer);
       assert.same(raw, original);
     });
+
+    it('returned items are the same', () => {
+      const arraySchema = schema(array({ test: integer }));
+      const arr = [{ test: 1 }];
+
+      const reader = arraySchema.read(arr);
+
+      assert.same(reader[0], reader[0]);
+    });
   });
 
   context('writer', () => {
@@ -270,6 +279,36 @@ describe('array', () => {
 
       refute.same(raw, reader);
       assert.same(raw, original);
+    });
+
+    it('does not return cached value after set', () => {
+      const arraySchema = schema(array({ test: integer }));
+      const arr = [{ test: 1 }];
+      const writer = arraySchema.write(arr);
+
+      assert.equals(writer[0], { test: 1 }); // read the value
+      writer[0] = { test: 2 };
+
+      assert.equals(writer[0], { test: 2 });
+    });
+
+    it('does not return cached value after splice', () => {
+      const arraySchema = schema(array({ test: integer }));
+      const arr = [{ test: 1 }, { test: 2 }];
+
+      const writer = arraySchema.write(arr);
+      writer.splice(0, 1);
+
+      assert.equals(writer[0], { test: 2 });
+    });
+
+    it('returned items are the same', () => {
+      const arraySchema = schema(array({ test: integer }));
+      const arr = [{ test: 1 }];
+
+      const writer = arraySchema.write(arr);
+
+      assert.same(writer[0], writer[0]);
     });
   });
 });

--- a/lib/create-item-getter.js
+++ b/lib/create-item-getter.js
@@ -2,8 +2,14 @@
 
 exports.createItemGetter = createItemGetter;
 
-function createItemGetter(valueTest, options, parent, read_write, makePath) {
-  const cache = Object.create(null);
+function createItemGetter(
+  cache,
+  valueTest,
+  options,
+  parent,
+  read_write,
+  makePath
+) {
   return (target, key) => {
     if (key === 'toJSON') {
       return () => target;

--- a/lib/map-verifyer.js
+++ b/lib/map-verifyer.js
@@ -33,8 +33,16 @@ function createVerify(keyVerify, valueTest) {
 
 function createMapValueReader(valueTest, verify) {
   return (map, options, base) => {
+    const cache = Object.create(null);
     return new Proxy(verify(unwrap(map), options), {
-      get: createItemGetter(valueTest, options, base, 'read', objectPath),
+      get: createItemGetter(
+        cache,
+        valueTest,
+        options,
+        base,
+        'read',
+        objectPath
+      ),
       set: failSet,
       deleteProperty: failDelete
     });
@@ -43,11 +51,19 @@ function createMapValueReader(valueTest, verify) {
 
 function createMapValueWriter(valueTest) {
   return (map, options, base) => {
+    const cache = Object.create(null);
     return new Proxy(unwrap(map), {
-      get: createItemGetter(valueTest, options, base, 'write', objectPath),
-      set: createItemSetter(valueTest, options, base),
+      get: createItemGetter(
+        cache,
+        valueTest,
+        options,
+        base,
+        'write',
+        objectPath
+      ),
+      set: createItemSetter(cache, valueTest, options, base),
       deleteProperty(target, key) {
-        if (options.emitter && typeof key === 'string') {
+        if (options && options.emitter && typeof key === 'string') {
           const path = objectPath(base, key);
           options.emitter.emit('delete', {
             type: 'object',
@@ -57,19 +73,20 @@ function createMapValueWriter(valueTest) {
             path
           });
         }
+        delete cache[key];
         return Reflect.deleteProperty(target, key);
       }
     });
   };
 }
 
-function createItemSetter(valueTest, options, base) {
+function createItemSetter(cache, valueTest, options, base) {
   return (target, key, value) => {
     if (typeof key === 'string') {
       value = unwrap(value);
       const path = objectPath(base, key);
       valueTest.verify(value, options, path);
-      if (options.emitter) {
+      if (options && options.emitter) {
         options.emitter.emit('set', {
           type: 'object',
           object: target,
@@ -80,6 +97,7 @@ function createItemSetter(valueTest, options, base) {
         });
       }
     }
+    delete cache[key];
     return Reflect.set(target, key, value);
   };
 }

--- a/lib/map.test.js
+++ b/lib/map.test.js
@@ -247,6 +247,13 @@ describe('map', () => {
       refute.same(raw, writer);
       assert.same(raw, original);
     });
+
+    it('returned items are the same', () => {
+      const mapSchema = schema(map(string, { num: integer }));
+      const reader = mapSchema.read({ test: { num: 42 } });
+
+      assert.same(reader.test, reader.test);
+    });
   });
 
   context('writer', () => {
@@ -268,6 +275,23 @@ describe('map', () => {
 
       refute.same(raw, reader);
       assert.same(raw, original);
+    });
+
+    it('does not return cached value after set', () => {
+      const mapSchema = schema(map(string, { num: integer }));
+      const writer = mapSchema.write({ test: { num: 42 } });
+
+      assert.equals(writer.test, { num: 42 }); // read the value
+      writer.test = { num: 7 };
+
+      assert.equals(writer.test, { num: 7 });
+    });
+
+    it('returned items are the same', () => {
+      const mapSchema = schema(map(string, { num: integer }));
+      const writer = mapSchema.write({ test: { num: 42 } });
+
+      assert.same(writer.test, writer.test);
     });
   });
 });

--- a/lib/object-verifyer.js
+++ b/lib/object-verifyer.js
@@ -55,8 +55,9 @@ function verifyWriter(verify, spec_options) {
 
 function createReader(tests, verify, spec_options) {
   return (object, options = spec_options, base = undefined) => {
+    const cache = Object.create(null);
     return new Proxy(verify(unwrap(object), options), {
-      get: createPropertyGetter(tests, options, base, 'read'),
+      get: createPropertyGetter(cache, tests, options, base, 'read'),
       set: failSet,
       deleteProperty: failDelete
     });
@@ -70,9 +71,10 @@ function createWriter(tests, spec_options) {
     for (const [key, value] of Object.entries(object)) {
       getTest(tests, key, base, options).verify(value, options, key, true);
     }
+    const cache = Object.create(null);
     return new Proxy(object, {
-      get: createPropertyGetter(tests, options, base, 'write'),
-      set: createPropertySetter(tests, options, base),
+      get: createPropertyGetter(cache, tests, options, base, 'write'),
+      set: createPropertySetter(cache, tests, options, base),
       deleteProperty(target, key) {
         if (options.emitter && typeof key === 'string') {
           const path = objectPath(base, key);
@@ -90,8 +92,7 @@ function createWriter(tests, spec_options) {
   };
 }
 
-function createPropertyGetter(tests, options, base, read_write) {
-  const cache = Object.create(null);
+function createPropertyGetter(cache, tests, options, base, read_write) {
   return (target, key) => {
     if (key === 'toJSON') {
       return () => target;
@@ -118,8 +119,9 @@ function createPropertyGetter(tests, options, base, read_write) {
   };
 }
 
-function createPropertySetter(tests, options, base) {
+function createPropertySetter(cache, tests, options, base) {
   return (target, key, value) => {
+    delete cache[key];
     if (typeof key === 'string') {
       value = unwrap(value);
       const path = objectPath(base, key);

--- a/lib/object.test.js
+++ b/lib/object.test.js
@@ -110,4 +110,33 @@ describe('object', () => {
       }
     );
   });
+
+  it('reader always returns the same object instance on read', () => {
+    const child = object({ name: string });
+    const parent = schema({ child });
+
+    const reader = parent.read({ child: { name: 'Test' } });
+
+    assert.same(reader.child, reader.child);
+  });
+
+  it('writer always returns the same object instance on read', () => {
+    const child = object({ name: string });
+    const parent = schema({ child });
+
+    const writer = parent.write({ child: { name: 'Test' } });
+
+    assert.same(writer.child, writer.child);
+  });
+
+  it('does not return cached value after set', () => {
+    const child = object({ name: string });
+    const parent = schema({ child });
+
+    const writer = parent.write({ child: { name: 'Test' } });
+    assert.equals(writer.child, { name: 'Test' }); // read the value
+    writer.child = { name: 'Updated' };
+
+    assert.equals(writer.child, { name: 'Updated' });
+  });
 });


### PR DESCRIPTION
This clears properties in the getter caches on modification.

Caching objects is required so that reading the same property always returns the same object instance. Therefore removing the cache is not an option.