### PR TITLE
Preserve cached instances

### DIFF
--- a/lib/array-verifyer.js
+++ b/lib/array-verifyer.js
@@ -33,9 +33,8 @@ function createVerify(itemTest) {
 
 function createArrayItemReader(itemTest, verify) {
   return (array, options = {}, base = undefined) => {
-    const cache = [];
     return new Proxy(verify(unwrap(array), options), {
-      get: createItemGetter(cache, itemTest, options, base, 'read', arrayPath),
+      get: createItemGetter(itemTest, options, base, 'read', arrayPath),
       set: failSet,
       deleteProperty: failDelete
     });
@@ -49,12 +48,10 @@ function createArrayItemWriter(itemTest, item_spec) {
     if (emitter) {
       emitArrayEvents(array, emitter, base, itemTest, item_spec);
     }
-    const cache = [];
     return new Proxy(array, {
-      get: createItemGetter(cache, itemTest, options, base, 'write', arrayPath),
+      get: createItemGetter(itemTest, options, base, 'write', arrayPath),
       set(target, key, value) {
         if (typeof key === 'string' && key !== 'length') {
-          delete cache[key];
           value = unwrap(value);
           const index = getArrayIndex(key, base);
           const path = arrayPath(base, index);
@@ -73,7 +70,6 @@ function createArrayItemWriter(itemTest, item_spec) {
         return Reflect.set(target, key, value);
       },
       deleteProperty(target, key) {
-        delete cache[key];
         if (emitter) {
           const index = getArrayIndex(key, base);
           const path = arrayPath(base, index);

--- a/lib/array.test.js
+++ b/lib/array.test.js
@@ -310,5 +310,16 @@ describe('array', () => {
 
       assert.same(writer[0], writer[0]);
     });
+
+    it('moved items are the same', () => {
+      const arraySchema = schema(array({ test: integer }));
+      const arr = [{ test: 1 }, { test: 2 }];
+
+      const writer = arraySchema.write(arr);
+      const second = writer[1];
+      writer.splice(0, 1);
+
+      assert.same(writer[0], second);
+    });
   });
 });

--- a/lib/create-item-getter.js
+++ b/lib/create-item-getter.js
@@ -2,14 +2,8 @@
 
 exports.createItemGetter = createItemGetter;
 
-function createItemGetter(
-  cache,
-  valueTest,
-  options,
-  parent,
-  read_write,
-  makePath
-) {
+function createItemGetter(valueTest, options, parent, read_write, makePath) {
+  const cache = new WeakMap();
   return (target, key) => {
     if (key === 'toJSON') {
       return () => target;
@@ -26,10 +20,12 @@ function createItemGetter(
     ) {
       const factory = valueTest.verify && valueTest.verify[read_write];
       if (factory) {
-        return (
-          cache[key] ||
-          (cache[key] = factory(value, options, makePath(parent, key)))
-        );
+        if (cache.has(value)) {
+          return cache.get(value);
+        }
+        const proxy = factory(value, options, makePath(parent, key));
+        cache.set(value, proxy);
+        return proxy;
       }
     }
     return value;

--- a/lib/map-verifyer.js
+++ b/lib/map-verifyer.js
@@ -33,16 +33,8 @@ function createVerify(keyVerify, valueTest) {
 
 function createMapValueReader(valueTest, verify) {
   return (map, options, base) => {
-    const cache = Object.create(null);
     return new Proxy(verify(unwrap(map), options), {
-      get: createItemGetter(
-        cache,
-        valueTest,
-        options,
-        base,
-        'read',
-        objectPath
-      ),
+      get: createItemGetter(valueTest, options, base, 'read', objectPath),
       set: failSet,
       deleteProperty: failDelete
     });
@@ -51,17 +43,9 @@ function createMapValueReader(valueTest, verify) {
 
 function createMapValueWriter(valueTest) {
   return (map, options, base) => {
-    const cache = Object.create(null);
     return new Proxy(unwrap(map), {
-      get: createItemGetter(
-        cache,
-        valueTest,
-        options,
-        base,
-        'write',
-        objectPath
-      ),
-      set: createItemSetter(cache, valueTest, options, base),
+      get: createItemGetter(valueTest, options, base, 'write', objectPath),
+      set: createItemSetter(valueTest, options, base),
       deleteProperty(target, key) {
         if (options && options.emitter && typeof key === 'string') {
           const path = objectPath(base, key);
@@ -73,14 +57,13 @@ function createMapValueWriter(valueTest) {
             path
           });
         }
-        delete cache[key];
         return Reflect.deleteProperty(target, key);
       }
     });
   };
 }
 
-function createItemSetter(cache, valueTest, options, base) {
+function createItemSetter(valueTest, options, base) {
   return (target, key, value) => {
     if (typeof key === 'string') {
       value = unwrap(value);
@@ -97,7 +80,6 @@ function createItemSetter(cache, valueTest, options, base) {
         });
       }
     }
-    delete cache[key];
     return Reflect.set(target, key, value);
   };
 }

--- a/lib/object-verifyer.js
+++ b/lib/object-verifyer.js
@@ -55,9 +55,8 @@ function verifyWriter(verify, spec_options) {
 
 function createReader(tests, verify, spec_options) {
   return (object, options = spec_options, base = undefined) => {
-    const cache = Object.create(null);
     return new Proxy(verify(unwrap(object), options), {
-      get: createPropertyGetter(cache, tests, options, base, 'read'),
+      get: createPropertyGetter(tests, options, base, 'read'),
       set: failSet,
       deleteProperty: failDelete
     });
@@ -71,10 +70,9 @@ function createWriter(tests, spec_options) {
     for (const [key, value] of Object.entries(object)) {
       getTest(tests, key, base, options).verify(value, options, key, true);
     }
-    const cache = Object.create(null);
     return new Proxy(object, {
-      get: createPropertyGetter(cache, tests, options, base, 'write'),
-      set: createPropertySetter(cache, tests, options, base),
+      get: createPropertyGetter(tests, options, base, 'write'),
+      set: createPropertySetter(tests, options, base),
       deleteProperty(target, key) {
         if (options.emitter && typeof key === 'string') {
           const path = objectPath(base, key);
@@ -92,7 +90,8 @@ function createWriter(tests, spec_options) {
   };
 }
 
-function createPropertyGetter(cache, tests, options, base, read_write) {
+function createPropertyGetter(tests, options, base, read_write) {
+  const cache = new WeakMap();
   return (target, key) => {
     if (key === 'toJSON') {
       return () => target;
@@ -109,19 +108,20 @@ function createPropertyGetter(cache, tests, options, base, read_write) {
       }
       const factory = test.verify && test.verify[read_write];
       if (factory) {
-        return (
-          cache[key] ||
-          (cache[key] = factory(value, options, objectPath(base, key)))
-        );
+        if (cache.has(value)) {
+          return cache.get(value);
+        }
+        const proxy = factory(value, options, objectPath(base, key));
+        cache.set(value, proxy);
+        return proxy;
       }
     }
     return value;
   };
 }
 
-function createPropertySetter(cache, tests, options, base) {
+function createPropertySetter(tests, options, base) {
   return (target, key, value) => {
-    delete cache[key];
     if (typeof key === 'string') {
       value = unwrap(value);
       const path = objectPath(base, key);


### PR DESCRIPTION
Cached instances where removed in #33, however existing cached instances in arrays should be preserved (see new test case for arrays).

With this change, the cache is a `WeakMap` with the original value used as the key. This way the actual index within the array does not matter and instances are correctly preserved even when the array index changes.