### PR TITLE
Fix missing proxy objects on results of `one` and `all` validators

### DIFF
--- a/lib/all.js
+++ b/lib/all.js
@@ -2,6 +2,8 @@
 
 const { lookup } = require('./registry');
 const { validator } = require('./validator');
+const { verifyer } = require('./verifyer');
+const { lazy } = require('./util');
 
 exports.all = all;
 
@@ -11,7 +13,8 @@ function all() {
   }
   const tests = Array.prototype.map.call(arguments, (spec) => lookup(spec));
 
-  return validator(allTester(tests), allSpecName(tests));
+  const tester = allTester(tests);
+  return validator(tester, allSpecName(tests), allVerifyer(tester, tests));
 }
 
 function allTester(tests) {
@@ -20,4 +23,24 @@ function allTester(tests) {
 
 function allSpecName(tests) {
   return () => `all(${tests.join(', ')})`;
+}
+
+function allVerifyer(tester, tests) {
+  const verify = verifyer(tester, tests);
+  lazy(verify, 'read', () => createAllReaderWriter(tests, 'read'));
+  lazy(verify, 'write', () => createAllReaderWriter(tests, 'write'));
+  return verify;
+}
+
+function createAllReaderWriter(tests, method) {
+  return (value, options = {}, base = undefined) => {
+    let result;
+    for (const test of tests) {
+      const readOrWrite = test.verify[method];
+      if (readOrWrite) {
+        result = readOrWrite(value, options, base);
+      }
+    }
+    return result;
+  };
 }

--- a/lib/all.test.js
+++ b/lib/all.test.js
@@ -106,4 +106,72 @@ describe('all', () => {
       allSchema({});
     });
   });
+
+  it('fails to access unknown property on reader', () => {
+    const allSchema = schema(all({ key: string }, () => true));
+
+    const proxy = allSchema.read({ key: 'test' });
+
+    assert.exception(
+      () => {
+        return proxy.foo;
+      },
+      {
+        name: 'ReferenceError',
+        message: 'Invalid property "foo"',
+        code: 'E_SCHEMA'
+      }
+    );
+  });
+
+  it('fails to access unknown property on writer', () => {
+    const allSchema = schema(all({ key: string }, () => true));
+
+    const proxy = allSchema.write({});
+
+    assert.exception(
+      () => {
+        return proxy.foo;
+      },
+      {
+        name: 'ReferenceError',
+        message: 'Invalid property "foo"',
+        code: 'E_SCHEMA'
+      }
+    );
+  });
+
+  it('fails to assign property on writer', () => {
+    const allSchema = schema(all({ key: string }, () => true));
+
+    const proxy = allSchema.write({});
+
+    assert.exception(
+      () => {
+        proxy.key = 11;
+      },
+      {
+        name: 'TypeError',
+        message: 'Expected property "key" to be string but got 11',
+        code: 'E_SCHEMA'
+      }
+    );
+  });
+
+  it('fails to assign property on writer (with custom validator first)', () => {
+    const allSchema = schema(all(() => true, { key: string }));
+
+    const proxy = allSchema.write({});
+
+    assert.exception(
+      () => {
+        proxy.key = 11;
+      },
+      {
+        name: 'TypeError',
+        message: 'Expected property "key" to be string but got 11',
+        code: 'E_SCHEMA'
+      }
+    );
+  });
 });

--- a/lib/one.js
+++ b/lib/one.js
@@ -2,6 +2,8 @@
 
 const { lookup } = require('./registry');
 const { validator } = require('./validator');
+const { verifyer } = require('./verifyer');
+const { lazy, failType } = require('./util');
 
 exports.one = one;
 
@@ -11,7 +13,8 @@ function one() {
   }
   const tests = Array.prototype.map.call(arguments, (spec) => lookup(spec));
 
-  return validator(oneTester(tests), oneSpecName(tests));
+  const tester = oneTester(tests);
+  return validator(tester, oneSpecName(tests), oneVerifyer(tester, tests));
 }
 
 function oneTester(tests) {
@@ -19,5 +22,33 @@ function oneTester(tests) {
 }
 
 function oneSpecName(tests) {
-  return () => `one(${tests.join(', ')})`;
+  return () => specName(tests);
+}
+
+function oneVerifyer(tester, tests) {
+  const verify = verifyer(tester, tests);
+  lazy(verify, 'read', () => createOneReaderWriter(tests, 'read'));
+  lazy(verify, 'write', () => createOneReaderWriter(tests, 'write'));
+  return verify;
+}
+
+function createOneReaderWriter(tests, method) {
+  return (value, options = {}, base = undefined) => {
+    for (const test of tests) {
+      const readOrWrite = test.verify[method];
+      if (readOrWrite) {
+        try {
+          return readOrWrite(value, options, base);
+        } catch (ignore) {
+          // Continue loop
+        }
+      }
+    }
+    failType(specName(tests), value, base, options.error_code);
+    return null; // make eslint happy
+  };
+}
+
+function specName(tests) {
+  return `one(${tests.join(', ')})`;
 }

--- a/lib/one.test.js
+++ b/lib/one.test.js
@@ -190,4 +190,72 @@ describe('one', () => {
       oneSchema({ bar: 1 });
     });
   });
+
+  it('fails to access unknown property on reader', () => {
+    const oneSchema = schema(one({ this: string }, { that: integer }));
+
+    const proxy = oneSchema.read({ this: 'test' });
+
+    assert.exception(
+      () => {
+        return proxy.foo;
+      },
+      {
+        name: 'ReferenceError',
+        message: 'Invalid property "foo"',
+        code: 'E_SCHEMA'
+      }
+    );
+  });
+
+  it('fails to access unknown property on writer', () => {
+    const oneSchema = schema(one({ this: string }, { that: integer }));
+
+    const proxy = oneSchema.write({});
+
+    assert.exception(
+      () => {
+        return proxy.foo;
+      },
+      {
+        name: 'ReferenceError',
+        message: 'Invalid property "foo"',
+        code: 'E_SCHEMA'
+      }
+    );
+  });
+
+  it('fails to assign property on writer', () => {
+    const oneSchema = schema(one({ key: string }, () => true));
+
+    const proxy = oneSchema.write({});
+
+    assert.exception(
+      () => {
+        proxy.key = 11;
+      },
+      {
+        name: 'TypeError',
+        message: 'Expected property "key" to be string but got 11',
+        code: 'E_SCHEMA'
+      }
+    );
+  });
+
+  it('fails to assign property on writer (with custom validator first)', () => {
+    const oneSchema = schema(one(() => true, { key: string }));
+
+    const proxy = oneSchema.write({});
+
+    assert.exception(
+      () => {
+        proxy.key = 11;
+      },
+      {
+        name: 'TypeError',
+        message: 'Expected property "key" to be string but got 11',
+        code: 'E_SCHEMA'
+      }
+    );
+  });
 });


### PR DESCRIPTION
When using `one(...)` or `all(...)` validators with objects, no proxy object would be created for the objects.

This patch fixes this with a custom verifyer for `one` and `all` which installs the missing `read` and `write` factory functions and delegates to the corresponding implementation of the wrapped tests.