### PR TITLE
Fix `read` and `write` for `one` and `all` with custom validators

### DIFF
--- a/lib/all.js
+++ b/lib/all.js
@@ -27,20 +27,20 @@ function allSpecName(tests) {
 
 function allVerifyer(tester, tests) {
   const verify = verifyer(tester, tests);
-  lazy(verify, 'read', () => createAllReaderWriter(tests, 'read'));
-  lazy(verify, 'write', () => createAllReaderWriter(tests, 'write'));
+  lazy(verify, 'read', () => createAllReaderWriter(tester, tests, 'read'));
+  lazy(verify, 'write', () => createAllReaderWriter(tester, tests, 'write'));
   return verify;
 }
 
-function createAllReaderWriter(tests, method) {
+function createAllReaderWriter(tester, tests, method) {
   return (value, options = {}, base = undefined) => {
-    let result;
+    tester.verify(value);
     for (const test of tests) {
       const readOrWrite = test.verify[method];
       if (readOrWrite) {
-        result = readOrWrite(value, options, base);
+        return readOrWrite(value, options, base);
       }
     }
-    return result;
+    return undefined;
   };
 }

--- a/lib/all.test.js
+++ b/lib/all.test.js
@@ -127,7 +127,7 @@ describe('all', () => {
   it('fails to access unknown property on writer', () => {
     const allSchema = schema(all({ key: string }, () => true));
 
-    const proxy = allSchema.write({});
+    const proxy = allSchema.write({ key: 'test' });
 
     assert.exception(
       () => {
@@ -144,7 +144,7 @@ describe('all', () => {
   it('fails to assign property on writer', () => {
     const allSchema = schema(all({ key: string }, () => true));
 
-    const proxy = allSchema.write({});
+    const proxy = allSchema.write({ key: 'test' });
 
     assert.exception(
       () => {
@@ -161,7 +161,7 @@ describe('all', () => {
   it('fails to assign property on writer (with custom validator first)', () => {
     const allSchema = schema(all(() => true, { key: string }));
 
-    const proxy = allSchema.write({});
+    const proxy = allSchema.write({ key: 'test' });
 
     assert.exception(
       () => {
@@ -170,6 +170,40 @@ describe('all', () => {
       {
         name: 'TypeError',
         message: 'Expected property "key" to be string but got 11',
+        code: 'E_SCHEMA'
+      }
+    );
+  });
+
+  it('succeeds on two custom validators', () => {
+    const allSchema = schema(
+      all(
+        () => true,
+        () => true
+      )
+    );
+
+    refute.exception(() => {
+      allSchema.write({});
+    });
+  });
+
+  it('fails on two custom validators', () => {
+    const allSchema = schema(
+      all(
+        () => true,
+        () => false
+      )
+    );
+
+    assert.exception(
+      () => {
+        allSchema.write({});
+      },
+      {
+        name: 'TypeError',
+        message:
+          'Expected all(<custom validator>, <custom validator>) but got {}',
         code: 'E_SCHEMA'
       }
     );

--- a/lib/one.js
+++ b/lib/one.js
@@ -3,7 +3,7 @@
 const { lookup } = require('./registry');
 const { validator } = require('./validator');
 const { verifyer } = require('./verifyer');
-const { lazy, failType } = require('./util');
+const { lazy } = require('./util');
 
 exports.one = one;
 
@@ -22,18 +22,19 @@ function oneTester(tests) {
 }
 
 function oneSpecName(tests) {
-  return () => specName(tests);
+  return () => `one(${tests.join(', ')})`;
 }
 
 function oneVerifyer(tester, tests) {
   const verify = verifyer(tester, tests);
-  lazy(verify, 'read', () => createOneReaderWriter(tests, 'read'));
-  lazy(verify, 'write', () => createOneReaderWriter(tests, 'write'));
+  lazy(verify, 'read', () => createOneReaderWriter(tester, tests, 'read'));
+  lazy(verify, 'write', () => createOneReaderWriter(tester, tests, 'write'));
   return verify;
 }
 
-function createOneReaderWriter(tests, method) {
+function createOneReaderWriter(tester, tests, method) {
   return (value, options = {}, base = undefined) => {
+    tester.verify(value);
     for (const test of tests) {
       const readOrWrite = test.verify[method];
       if (readOrWrite) {
@@ -44,11 +45,6 @@ function createOneReaderWriter(tests, method) {
         }
       }
     }
-    failType(specName(tests), value, base, options.error_code);
-    return null; // make eslint happy
+    return undefined;
   };
-}
-
-function specName(tests) {
-  return `one(${tests.join(', ')})`;
 }

--- a/lib/one.test.js
+++ b/lib/one.test.js
@@ -211,7 +211,7 @@ describe('one', () => {
   it('fails to access unknown property on writer', () => {
     const oneSchema = schema(one({ this: string }, { that: integer }));
 
-    const proxy = oneSchema.write({});
+    const proxy = oneSchema.write({ that: 42 });
 
     assert.exception(
       () => {
@@ -228,7 +228,7 @@ describe('one', () => {
   it('fails to assign property on writer', () => {
     const oneSchema = schema(one({ key: string }, () => true));
 
-    const proxy = oneSchema.write({});
+    const proxy = oneSchema.write({ key: 'test' });
 
     assert.exception(
       () => {
@@ -245,7 +245,7 @@ describe('one', () => {
   it('fails to assign property on writer (with custom validator first)', () => {
     const oneSchema = schema(one(() => true, { key: string }));
 
-    const proxy = oneSchema.write({});
+    const proxy = oneSchema.write({ key: 'test' });
 
     assert.exception(
       () => {
@@ -257,5 +257,50 @@ describe('one', () => {
         code: 'E_SCHEMA'
       }
     );
+  });
+
+  it('succeeds on two custom validators', () => {
+    const oneSchema = schema(
+      one(
+        () => false,
+        () => true
+      )
+    );
+
+    refute.exception(() => {
+      oneSchema.write({});
+    });
+  });
+
+  it('fails on two custom validators', () => {
+    const oneSchema = schema(
+      one(
+        () => false,
+        () => false
+      )
+    );
+
+    assert.exception(
+      () => {
+        oneSchema.write({});
+      },
+      {
+        name: 'TypeError',
+        message:
+          'Expected one(<custom validator>, <custom validator>) but got {}',
+        code: 'E_SCHEMA'
+      }
+    );
+  });
+
+  it('succeeds on one(null, { test: integer })', () => {
+    const oneSchema = schema(one(null, { test: integer }));
+
+    refute.exception(() => {
+      oneSchema.write(null);
+    });
+    refute.exception(() => {
+      oneSchema.write({ test: 1 });
+    });
   });
 });


### PR DESCRIPTION
The previous fix in #35 did not handle all cases with custom validators correctly. This patch improves and simplifies the implementation.