### PR TITLE
Fix usage of invalid `WeakMap` keys

### DIFF
--- a/lib/all.js
+++ b/lib/all.js
@@ -27,14 +27,14 @@ function allSpecName(tests) {
 
 function allVerifyer(tester, tests) {
   const verify = verifyer(tester, tests);
-  lazy(verify, 'read', () => createAllReaderWriter(tester, tests, 'read'));
-  lazy(verify, 'write', () => createAllReaderWriter(tester, tests, 'write'));
+  lazy(verify, 'read', () => createAllReaderWriter(verify, tests, 'read'));
+  lazy(verify, 'write', () => createAllReaderWriter(verify, tests, 'write'));
   return verify;
 }
 
-function createAllReaderWriter(tester, tests, method) {
+function createAllReaderWriter(verify, tests, method) {
   return (value, options = {}, base = undefined) => {
-    tester.verify(value);
+    verify(value);
     for (const test of tests) {
       const readOrWrite = test.verify[method];
       if (readOrWrite) {

--- a/lib/create-item-getter.js
+++ b/lib/create-item-getter.js
@@ -9,25 +9,24 @@ function createItemGetter(valueTest, options, parent, read_write, makePath) {
       return () => target;
     }
     const value = Reflect.get(target, key);
-    if (key === 'length') {
-      return value;
-    }
     // Key might be Symbol and value a prototype function:
     if (
-      typeof key === 'string' &&
-      typeof value !== 'undefined' &&
-      typeof value !== 'function'
+      key === 'length' ||
+      value === null ||
+      typeof key !== 'string' ||
+      typeof value !== 'object'
     ) {
-      const factory = valueTest.verify && valueTest.verify[read_write];
-      if (factory) {
-        if (cache.has(value)) {
-          return cache.get(value);
-        }
-        const proxy = factory(value, options, makePath(parent, key));
-        cache.set(value, proxy);
-        return proxy;
-      }
+      return value;
     }
-    return value;
+    const factory = valueTest.verify && valueTest.verify[read_write];
+    if (!factory) {
+      return value;
+    }
+    if (cache.has(value)) {
+      return cache.get(value);
+    }
+    const proxy = factory(value, options, makePath(parent, key));
+    cache.set(value, proxy);
+    return proxy;
   };
 }

--- a/lib/map.test.js
+++ b/lib/map.test.js
@@ -254,6 +254,16 @@ describe('map', () => {
 
       assert.same(reader.test, reader.test);
     });
+
+    it('does not fail on reader for property with one(null, ...)', () => {
+      const test = schema(map(string, one(null, string)));
+
+      const reader = test.read({ test: null });
+
+      refute.exception(() => {
+        return reader.test;
+      });
+    });
   });
 
   context('writer', () => {
@@ -292,6 +302,36 @@ describe('map', () => {
       const writer = mapSchema.write({ test: { num: 42 } });
 
       assert.same(writer.test, writer.test);
+    });
+
+    it('does not fail on writer for property with one(null, ...)', () => {
+      const test = schema(map(string, one(null, string)));
+
+      const writer = test.write({ test: null });
+
+      refute.exception(() => {
+        return writer.test;
+      });
+    });
+
+    it('does not fail on writer for property with one(integer, ...)', () => {
+      const test = schema(map(string, one(integer, string)));
+
+      const writer = test.write({ test: 1 });
+
+      refute.exception(() => {
+        return writer.test;
+      });
+    });
+
+    it('does not fail on writer for property with one(string, ...)', () => {
+      const test = schema(map(string, one(string, integer)));
+
+      const writer = test.write({ test: 'test' });
+
+      refute.exception(() => {
+        return writer.test;
+      });
     });
   });
 });

--- a/lib/object-verifyer.js
+++ b/lib/object-verifyer.js
@@ -101,22 +101,23 @@ function createPropertyGetter(tests, options, base, read_write) {
     }
     const value = Reflect.get(target, key);
     // Key might be Symbol and value a prototype function:
-    if (typeof key === 'string' && typeof value !== 'function') {
-      const test = getTest(tests, key, base, options);
-      if (value === undefined) {
-        return value;
-      }
-      const factory = test.verify && test.verify[read_write];
-      if (factory) {
-        if (cache.has(value)) {
-          return cache.get(value);
-        }
-        const proxy = factory(value, options, objectPath(base, key));
-        cache.set(value, proxy);
-        return proxy;
-      }
+    if (typeof key !== 'string' || typeof value === 'function') {
+      return value;
     }
-    return value;
+    const test = getTest(tests, key, base, options);
+    if (value === null || typeof value !== 'object') {
+      return value;
+    }
+    const factory = test.verify && test.verify[read_write];
+    if (!factory) {
+      return value;
+    }
+    if (cache.has(value)) {
+      return cache.get(value);
+    }
+    const proxy = factory(value, options, objectPath(base, key));
+    cache.set(value, proxy);
+    return proxy;
   };
 }
 

--- a/lib/object.test.js
+++ b/lib/object.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { assert, refute } = require('@sinonjs/referee-sinon');
-const { schema, object, integer, string } = require('..');
+const { schema, object, integer, string, one } = require('..');
 
 describe('object', () => {
   it('requires object argument', () => {
@@ -138,5 +138,45 @@ describe('object', () => {
     writer.child = { name: 'Updated' };
 
     assert.equals(writer.child, { name: 'Updated' });
+  });
+
+  it('does not fail on reader for property with one(null, ...)', () => {
+    const test = schema({ test: one(null, string) });
+
+    const reader = test.read({ test: null });
+
+    refute.exception(() => {
+      return reader.test;
+    });
+  });
+
+  it('does not fail on writer for property with one(null, ...)', () => {
+    const test = schema({ test: one(null, string) });
+
+    const writer = test.write({ test: null });
+
+    refute.exception(() => {
+      return writer.test;
+    });
+  });
+
+  it('does not fail on writer for property with one(integer, ...)', () => {
+    const test = schema({ test: one(integer, string) });
+
+    const writer = test.write({ test: 1 });
+
+    refute.exception(() => {
+      return writer.test;
+    });
+  });
+
+  it('does not fail on writer for property with one(string, ...)', () => {
+    const test = schema({ test: one(string, integer) });
+
+    const writer = test.write({ test: 'test' });
+
+    refute.exception(() => {
+      return writer.test;
+    });
   });
 });

--- a/lib/one.js
+++ b/lib/one.js
@@ -27,14 +27,14 @@ function oneSpecName(tests) {
 
 function oneVerifyer(tester, tests) {
   const verify = verifyer(tester, tests);
-  lazy(verify, 'read', () => createOneReaderWriter(tester, tests, 'read'));
-  lazy(verify, 'write', () => createOneReaderWriter(tester, tests, 'write'));
+  lazy(verify, 'read', () => createOneReaderWriter(verify, tests, 'read'));
+  lazy(verify, 'write', () => createOneReaderWriter(verify, tests, 'write'));
   return verify;
 }
 
-function createOneReaderWriter(tester, tests, method) {
+function createOneReaderWriter(verify, tests, method) {
   return (value, options = {}, base = undefined) => {
-    tester.verify(value);
+    verify(value);
     for (const test of tests) {
       const readOrWrite = test.verify[method];
       if (readOrWrite) {


### PR DESCRIPTION
`WeakMap` can not be used with primitive values as keys.