### PR TITLE
Expose regexp validator creation on `string.regexp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ const person = schema({ name: string });
 - `integer.range(min, max)`: Is a validator that accepts finite integer values
   > = `min` and <= `max`.
 - `string`: Is a validator that accepts string values.
+- `string.regexp(re)`: Is a validator that accepts string values matching the
+  given regular expression.
+- `string.length.{min,max,range}`: Verifies the string length with an integer
+  validator.
 - `object`: Is a validator that accepts object values.
 - `array`: Is a validator that accepts array values.
 - `literal(value_1, value_2, ...)`: Returns a validator that matches against a

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -3,6 +3,7 @@
 const { typeOf, failSpec } = require('./util');
 const { validator } = require('./validator');
 const { literal } = require('./literal');
+const { string } = require('./string');
 
 exports.lookup = lookup;
 exports.registerType = registerType;
@@ -11,7 +12,7 @@ exports.registerValue = registerValue;
 const by_value = new Map();
 const by_type = {
   Null: () => literal(null),
-  RegExp: regexp,
+  RegExp: string.regexp,
   Function: func
 };
 
@@ -30,13 +31,6 @@ function func(spec, spec_options) {
     return spec;
   }
   return validator(spec.bind(), spec.name);
-}
-
-function regexp(spec) {
-  return validator(
-    (value) => typeof value === 'string' && spec.test(value),
-    String(spec)
-  );
 }
 
 function registerType(type, handler) {

--- a/lib/string.js
+++ b/lib/string.js
@@ -26,6 +26,14 @@ Object.defineProperty(string, 'length', {
   }
 });
 
+Object.defineProperty(string, 'regexp', {
+  value: (regexp) =>
+    validator(
+      (value) => typeof value === 'string' && regexp.test(value),
+      String(regexp)
+    )
+});
+
 exports.string = string;
 
 function isString(v) {

--- a/lib/string.test.js
+++ b/lib/string.test.js
@@ -78,6 +78,39 @@ describe('string', () => {
     });
   });
 
+  context('regexp', () => {
+    const validator = string.regexp(/[0-9]+/);
+
+    it('returns true for matching string', () => {
+      assert.isTrue(validator('0'));
+      assert.isTrue(validator('42'));
+    });
+
+    it('returns false for non-matching string', () => {
+      assert.isFalse(validator(''));
+      assert.isFalse(validator('abc'));
+    });
+
+    context('verify', () => {
+      it('returns a valid string', () => {
+        assert.equals(validator.verify('123'), '123');
+      });
+
+      it('throws for an invalid string', () => {
+        assert.exception(
+          () => {
+            validator.verify('abcd');
+          },
+          {
+            name: 'TypeError',
+            code: 'E_SCHEMA',
+            message: 'Expected /[0-9]+/ but got "abcd"'
+          }
+        );
+      });
+    });
+  });
+
   context('length.min.verify', () => {
     const string_length = string.length.min(5);
 


### PR DESCRIPTION
This adds `string.regexp(spec)` to create a validator for a given regular expression.