### PR TITLE
Expose processed specs

### DIFF
--- a/lib/array.js
+++ b/lib/array.js
@@ -22,6 +22,7 @@ function array(spec) {
     arrayVerifyer(itemTest, spec)
   );
   test.type = 'Array';
+  test.items = itemTest;
   return test;
 }
 

--- a/lib/array.test.js
+++ b/lib/array.test.js
@@ -179,6 +179,15 @@ describe('array', () => {
     assert.equals(validator.type, 'Array');
   });
 
+  it('exposes processed items spec', () => {
+    const spec = /[a-z]/;
+
+    const validator = array(spec);
+
+    refute.same(validator.items, spec);
+    assert.same(validator.items.type, 'string');
+  });
+
   context('reader', () => {
     it('returns original object for toJSON', () => {
       const arraySchema = schema(array({ test: integer }));

--- a/lib/literal.js
+++ b/lib/literal.js
@@ -9,9 +9,12 @@ function literal() {
   if (arguments.length === 0) {
     throw new Error('Require at least one argument');
   }
-  const values = Array.prototype.slice.call(arguments);
+  const values = Object.freeze(Array.prototype.slice.call(arguments));
 
-  return validator(literalTester(values), literalSpecName(values));
+  const test = validator(literalTester(values), literalSpecName(values));
+  test.type = 'literal';
+  test.values = values;
+  return test;
 }
 
 function literalTester(values) {

--- a/lib/literal.test.js
+++ b/lib/literal.test.js
@@ -4,6 +4,21 @@ const { assert, refute } = require('@sinonjs/referee-sinon');
 const { schema, literal } = require('..');
 
 describe('literal', () => {
+  it('has type "literal"', () => {
+    const validator = literal(null);
+
+    assert.equals(validator.type, 'literal');
+  });
+
+  it('exposes frozen values', () => {
+    const values = [1, 2, 3];
+
+    const validator = literal(...values);
+
+    assert.equals(validator.values, values);
+    assert.isTrue(Object.isFrozen(validator.values));
+  });
+
   it('throws if no arguments are given', () => {
     assert.exception(
       () => {

--- a/lib/map.js
+++ b/lib/map.js
@@ -11,11 +11,15 @@ function map(key_spec, value_spec) {
   const keyTest = lookup(key_spec);
   const valueTest = lookup(value_spec);
 
-  return validator(
+  const test = validator(
     mapTester(keyTest, valueTest),
     mapSpecName(keyTest, valueTest),
     mapVerifyer(keyVerifyer(keyTest), valueTest)
   );
+  test.type = 'Map';
+  test.keys = keyTest;
+  test.values = valueTest;
+  return test;
 }
 
 function mapTester(keyTest, valueTest) {

--- a/lib/map.test.js
+++ b/lib/map.test.js
@@ -13,6 +13,30 @@ const {
 } = require('..');
 
 describe('map', () => {
+  it('has type "Map"', () => {
+    const validator = map(string, string);
+
+    assert.equals(validator.type, 'Map');
+  });
+
+  it('exposes processed keys spec', () => {
+    const spec = /[a-z]/;
+
+    const validator = map(spec, string);
+
+    refute.same(validator.keys, spec);
+    assert.same(validator.keys.type, 'string');
+  });
+
+  it('exposes processed values spec', () => {
+    const spec = /[a-z]/;
+
+    const validator = map(string, spec);
+
+    refute.same(validator.values, spec);
+    assert.same(validator.values.type, 'string');
+  });
+
   it('requires both arguments to be valid specs', () => {
     assert.exception(
       () => {

--- a/lib/object.js
+++ b/lib/object.js
@@ -12,15 +12,16 @@ registerValue(object, validator(isObject, 'object'));
 
 function object(spec, spec_options) {
   assertType(spec, 'Object');
-  const tests = lookupAll(spec);
+  const properties = lookupAll(spec);
 
   const test = validator(
-    objectTester(tests),
+    objectTester(properties),
     objectSpecName(spec),
-    objectVerifyer(tests, spec_options)
+    objectVerifyer(properties, spec_options)
   );
   test.spec = spec;
   test.type = 'Object';
+  test.properties = properties;
   return test;
 }
 
@@ -28,11 +29,11 @@ function isObject(value) {
   return typeOf(value) === 'Object';
 }
 
-function objectTester(tests) {
+function objectTester(properties) {
   return (value) =>
     isObject(value) &&
-    Object.keys(tests).every((key) => tests[key](value[key], key)) &&
-    Object.keys(value).every((key) => Boolean(tests[key]));
+    Object.keys(properties).every((key) => properties[key](value[key], key)) &&
+    Object.keys(value).every((key) => Boolean(properties[key]));
 }
 
 function objectSpecName(spec) {

--- a/lib/object.test.js
+++ b/lib/object.test.js
@@ -46,6 +46,16 @@ describe('object', () => {
     assert.equals(validator.type, 'Object');
   });
 
+  it('exposes processed properties spec', () => {
+    const spec = { int: integer, re: /[a-z]/ };
+
+    const validator = object(spec);
+
+    refute.same(validator.properties, spec);
+    assert.same(validator.properties.int, spec.int);
+    assert.same(validator.properties.re.type, 'string');
+  });
+
   it('verifies object', () => {
     const objectSchema = schema(object({ test: integer }));
 

--- a/lib/opt.js
+++ b/lib/opt.js
@@ -2,14 +2,21 @@
 
 const { lookup } = require('./registry');
 const { validator } = require('./validator');
-const { copyPropertyDescriptor } = require('./util');
+const { copyPropertyDescriptor, copyTypeAndProperties } = require('./util');
 
 exports.opt = opt;
 
 function opt(spec) {
   const test = lookup(spec);
 
-  return validator(optTester(test), optSpecName(test), optVerifyer(test));
+  const wrapped = validator(
+    optTester(test),
+    optSpecName(test),
+    optVerifyer(test)
+  );
+  wrapped.optional = true;
+  copyTypeAndProperties(test, wrapped);
+  return wrapped;
 }
 
 function optTester(test) {

--- a/lib/opt.test.js
+++ b/lib/opt.test.js
@@ -1,9 +1,48 @@
 'use strict';
 
 const { assert, refute, sinon } = require('@sinonjs/referee-sinon');
-const { schema, array, opt, boolean, number, integer, string } = require('..');
+const {
+  schema,
+  object,
+  array,
+  opt,
+  boolean,
+  number,
+  integer,
+  string
+} = require('..');
 
 describe('opt', () => {
+  it('has type of wrapped spec', () => {
+    assert.equals(opt(boolean).type, 'boolean');
+    assert.equals(opt(number).type, 'number');
+    assert.equals(opt(string).type, 'string');
+  });
+
+  it('has optional = true', () => {
+    assert.isTrue(opt(boolean).optional);
+    assert.isTrue(opt(number).optional);
+    assert.isTrue(opt(string).optional);
+  });
+
+  it('has properties of wrapped object', () => {
+    const obj = object({ num: number });
+
+    const optional = opt(obj);
+
+    assert.equals(optional.type, 'Object');
+    assert.equals(optional.properties, obj.properties);
+  });
+
+  it('has items of wrapped array', () => {
+    const numbers = array(number);
+
+    const optional = opt(numbers);
+
+    assert.equals(optional.type, 'Array');
+    assert.same(optional.items, numbers.items);
+  });
+
   it('works with undefined or string', () => {
     const optSchema = schema(opt(string));
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { lookup } = require('./registry');
-const { copyPropertyDescriptor } = require('./util');
+const { copyPropertyDescriptor, copyTypeAndProperties } = require('./util');
 
 exports.schema = schema;
 
@@ -10,6 +10,7 @@ function schema(spec, spec_options = {}) {
   const verifyer = createVerifyer(validator, spec_options);
   copyPropertyDescriptor(validator.verify, 'read', verifyer);
   copyPropertyDescriptor(validator.verify, 'write', verifyer);
+  copyTypeAndProperties(validator, verifyer);
   verifyer.verify = validator.verify.verify;
   return verifyer;
 }

--- a/lib/schema.test.js
+++ b/lib/schema.test.js
@@ -17,6 +17,36 @@ describe('schema', () => {
     assert.isFunction(validate.verify);
   });
 
+  it('exposes spec type Object', () => {
+    const spec = { test: schema.number };
+
+    const validate = schema(spec);
+
+    assert.same(validate.type, 'Object');
+    assert.equals(validate.properties, { test: schema.number });
+  });
+
+  it('exposes spec type Array', () => {
+    const spec = [schema.number];
+
+    const validate = schema(spec);
+
+    assert.same(validate.type, 'Array');
+    assert.same(validate.items, schema.number);
+  });
+
+  it('exposes spec type number', () => {
+    const validate = schema(schema.number);
+
+    assert.same(validate.type, 'number');
+  });
+
+  it('exposes spec type string', () => {
+    const validate = schema(schema.string);
+
+    assert.same(validate.type, 'string');
+  });
+
   it('does not invoke the given validator property accessors', () => {
     const object = schema.object({});
     const read = sinon.replaceGetter(object.verify, 'read', sinon.fake());

--- a/lib/util.js
+++ b/lib/util.js
@@ -10,6 +10,7 @@ exports.assertType = assertType;
 exports.lazy = lazy;
 exports.typeOf = typeOf;
 exports.stringify = stringify;
+exports.copyTypeAndProperties = copyTypeAndProperties;
 exports.copyPropertyDescriptor = copyPropertyDescriptor;
 
 exports.failSchemaValidation = failSchemaValidation;
@@ -99,6 +100,20 @@ function copyPropertyDescriptor(from, name, to) {
   const desc = Object.getOwnPropertyDescriptor(from, name);
   if (desc) {
     Object.defineProperty(to, name, desc);
+  }
+}
+
+function copyTypeAndProperties(from, to) {
+  to.type = from.type;
+  switch (from.type) {
+    case 'Object':
+      to.properties = from.properties;
+      break;
+    case 'Array':
+      to.items = from.items;
+      break;
+    default:
+    // Do nothing
   }
 }
 

--- a/lib/util.test.js
+++ b/lib/util.test.js
@@ -10,7 +10,8 @@ const {
   lazy,
   typeOf,
   stringify,
-  copyPropertyDescriptor
+  copyPropertyDescriptor,
+  copyTypeAndProperties
 } = require('./util');
 
 describe('util', () => {
@@ -361,6 +362,43 @@ describe('util', () => {
         configurable: false,
         enumerable: true
       });
+    });
+  });
+
+  describe('copyTypeAndProperties', () => {
+    it('copies the type', () => {
+      const from = { type: 'test', something: 42 };
+      const to = { previous: true };
+
+      copyTypeAndProperties(from, to);
+
+      assert.equals(to, { type: 'test', previous: true });
+    });
+
+    it('copies the properties if type is Object', () => {
+      const from = {
+        type: 'Object',
+        properties: Symbol('properties'),
+        something: 42
+      };
+      const to = { previous: true };
+
+      copyTypeAndProperties(from, to);
+
+      assert.equals(to, {
+        type: 'Object',
+        properties: from.properties,
+        previous: true
+      });
+    });
+
+    it('copies the items if type is Array', () => {
+      const from = { type: 'Array', items: Symbol('items'), something: 42 };
+      const to = { previous: true };
+
+      copyTypeAndProperties(from, to);
+
+      assert.equals(to, { type: 'Array', items: from.items, previous: true });
     });
   });
 });


### PR DESCRIPTION
- Expose the `type` of `literal` and `map` specs
- Expose the array item validator as `items`
- Expose the object property validator as `properties`
- Expose the map key validator as `keys` and the value validator as `values`
- Expose the type of `opt` and the corresponding properties
- Expose the type of schemas and the corresponding properties