### PR TITLE
Fix integer map key validator

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -23,9 +23,20 @@ function map(key_spec, value_spec) {
 }
 
 function mapTester(keyTest, valueTest) {
+  const actualKeyTest =
+    keyTest.type === 'integer' ? integerKeyTest(keyTest) : keyTest;
   return (value) =>
     typeOf(value) === 'Object' &&
-    Object.keys(value).every((key) => keyTest(key) && valueTest(value[key]));
+    Object.keys(value).every(
+      (key) => actualKeyTest(key) && valueTest(value[key])
+    );
+}
+
+function integerKeyTest(keyTest) {
+  return (key) => {
+    const integer_key = parseInt(key, 10);
+    return String(integer_key) === key && keyTest(integer_key);
+  };
 }
 
 function mapSpecName(keyTest, valueTest) {

--- a/lib/map.test.js
+++ b/lib/map.test.js
@@ -159,6 +159,13 @@ describe('map', () => {
     );
   });
 
+  it('supports integer keys in validator', () => {
+    const mapValidator = map(integer, string);
+
+    assert.isTrue(mapValidator({ 0: 'passes' }));
+    assert.isFalse(mapValidator({ test: 'fails' }));
+  });
+
   it('fails for invalid objects', () => {
     const mapSchema = schema(map(string, number));
 


### PR DESCRIPTION
Maps with integer keys could not be used as validators.