### PR TITLE
Fix invalid property not verified in combination with opt

### DIFF
--- a/lib/object-verifyer.js
+++ b/lib/object-verifyer.js
@@ -31,7 +31,7 @@ function createVerify(tests) {
       const test = getTest(tests, key, base, options);
       test.verify(value[key], options, objectPath(base, key));
     }
-    if (!opt && value_keys.length !== test_keys.length) {
+    if (!opt) {
       for (const key of value_keys) {
         getTest(tests, key, base, options);
       }

--- a/lib/object.test.js
+++ b/lib/object.test.js
@@ -65,6 +65,17 @@ describe('object', () => {
     assert.isFalse(validator({ name: 123 }));
   });
 
+  it('validates an object with optional property', () => {
+    const validator = object({ age: opt(integer) });
+
+    assert.isTrue(validator({}));
+    assert.isTrue(validator({ age: 123 }));
+    // @ts-expect-error
+    assert.isFalse(validator({ age: '123' }));
+    // @ts-expect-error
+    assert.isFalse(validator({ invalid: true }));
+  });
+
   it('validates nested object with validator', () => {
     const validator = object({ child: object({ name: string }) });
 

--- a/lib/schema_object.test.js
+++ b/lib/schema_object.test.js
@@ -8,6 +8,7 @@ const {
   object,
   array,
   map,
+  integer,
   number,
   string,
   opt,
@@ -105,6 +106,24 @@ describe('schema object', () => {
         code: 'E_SCHEMA'
       }
     );
+  });
+
+  it('validates optional object property with type integer', () => {
+    const test = schema(object({ age: opt(integer) }));
+
+    refute.exception(() => test({ age: 42 }));
+    // @ts-expect-error
+    assert.exception(() => test({ age: '42' }), {
+      name: 'TypeError',
+      message: 'Expected property "age" to be integer but got "42"',
+      code: 'E_SCHEMA'
+    });
+    // @ts-expect-error
+    assert.exception(() => test({ other: true }), {
+      name: 'ReferenceError',
+      message: 'Invalid property "other"',
+      code: 'E_SCHEMA'
+    });
   });
 
   it('validates object property with type object.any', () => {


### PR DESCRIPTION
Fixes an issue where an invalid property doesn't cause an exception if it's provided in place of an optional property.

In this case, the optional property doesn't throw, because it's fine to not provide it, and the following checks on the provided properties was skipped, because the length of both key array is the same.